### PR TITLE
Add macos-latest to workflow actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build and Verify
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Michael Froh <froh@amazon.com>

### Description
This PR was generated by a script.

In order to get a rough idea of the effort required to build a MacOS
distribution of OpenSearch, a good first step is enabling MacOS builds
wherever we build for Windows.

Rather than opening an issue in every repo asking maintainers to add
`macos-latest` to their `matrix.os`, I've decided to try automating it
to see what works and what breaks.

### Next steps
If you're reviewing this PR, you may be wondering what to do with it.

**Did the checks pass?** Great! You can probably safely merge the PR 
and let your build workflows run on MacOS.

**Did the checks fail?** You can discard this PR or ignore it. @msfroh
will track the failure and document it. If many PRs see check failures
with the same root cause, we may try to address that and repeat this 
experiment.
